### PR TITLE
fix(vectorstore): Correct HNSW parameter inclusion and test assertions

### DIFF
--- a/src/langchain_google_memorystore_redis/vectorstore.py
+++ b/src/langchain_google_memorystore_redis/vectorstore.py
@@ -321,11 +321,12 @@ class RedisVectorStore(VectorStore):
         command = (
             f"FT.CREATE {index_config.name} ON HASH PREFIX 1 {RedisVectorStore.get_key_prefix(index_config.name)} "
             f"SCHEMA {index_config.field_name} VECTOR {index_config.type} "
-            f"6 TYPE {index_config.data_type} DIM {index_config.vector_size} "
+            f"14 TYPE {index_config.data_type} DIM {index_config.vector_size} "
             f"DISTANCE_METRIC {index_config.distance_metric} "
+            f"TYPE {index_config.data_type} "
             f"M {index_config.m} "
             f"EF_CONSTRUCTION {index_config.ef_construction} "
-            f"EF_RUNTIME {index_config.ef_construction}"
+            f"EF_RUNTIME {index_config.ef_runtime}"
         )
 
         try:

--- a/src/langchain_google_memorystore_redis/vectorstore.py
+++ b/src/langchain_google_memorystore_redis/vectorstore.py
@@ -322,7 +322,10 @@ class RedisVectorStore(VectorStore):
             f"FT.CREATE {index_config.name} ON HASH PREFIX 1 {RedisVectorStore.get_key_prefix(index_config.name)} "
             f"SCHEMA {index_config.field_name} VECTOR {index_config.type} "
             f"6 TYPE {index_config.data_type} DIM {index_config.vector_size} "
-            f"DISTANCE_METRIC {index_config.distance_metric}"
+            f"DISTANCE_METRIC {index_config.distance_metric} "
+            f"M {index_config.m} "
+            f"EF_CONSTRUCTION {index_config.ef_construction} "
+            f"EF_RUNTIME {index_config.ef_construction}"
         )
 
         try:

--- a/tests/test_memorystore_redis_vectorstore.py
+++ b/tests/test_memorystore_redis_vectorstore.py
@@ -134,8 +134,7 @@ def test_vector_store_add_texts(texts, metadatas, ids):
 
     # Verify no extra keys are present
     all_keys = [key.decode("utf-8") for key in client.keys(f"{index_name}*")]
-    # Currently RedisQuery stores the index schema as a key using the index_name
-    assert len(all_keys) == len(returned_ids) + 1, "Found unexpected keys in Redis"
+    assert len(all_keys) == len(returned_ids), "Found unexpected keys in Redis"
 
     # Clena up
     RedisVectorStore.drop_index(client=client, index_name=index_name)
@@ -233,7 +232,7 @@ def test_vector_store_range_query(distance_strategy, distance_threshold):
 
 
 def check_index_exists(
-    client: redis.Redis, index_name: str, index_config: VectorIndexConfig
+    client: redis.Redis, index_name: str, index_config: HNSWConfig
 ) -> bool:
     try:
         index_info = client.ft(index_name).info()
@@ -243,6 +242,17 @@ def check_index_exists(
     return (
         index_info["index_name"] == index_name
         and index_info["index_definition"][1] == b"HASH"
+        and index_info["index_definition"][3][0].decode("utf-8") == index_config.name
+        and index_info["attributes"][0][1].decode("utf-8") == index_config.field_name
+        and index_info["attributes"][0][3].decode("utf-8") == index_config.field_name
+        and index_info["attributes"][0][5] == b'VECTOR'
+        and index_info["attributes"][0][7][3] == index_config.vector_size
+        and index_info["attributes"][0][7][5].decode("utf-8") == index_config.distance_metric
+        and index_info["attributes"][0][7][7].decode("utf-8") == index_config.data_type
+        and index_info["attributes"][0][7][9][1] == b'HNSW'
+        and index_info["attributes"][0][7][9][3] == index_config.m
+        and index_info["attributes"][0][7][9][5] == index_config.ef_construction
+        and index_info["attributes"][0][7][9][7] == index_config.ef_runtime
     )
 
 

--- a/tests/test_memorystore_redis_vectorstore.py
+++ b/tests/test_memorystore_redis_vectorstore.py
@@ -36,7 +36,12 @@ def test_vector_store_init_index():
     index_name = str(uuid.uuid4())
 
     index_config = HNSWConfig(
-        name=index_name, distance_strategy=DistanceStrategy.COSINE, vector_size=128
+        name=index_name,
+        distance_strategy=DistanceStrategy.COSINE,
+        vector_size=128,
+        m=1,
+        ef_construction=2,
+        ef_runtime=3,
     )
 
     assert not check_index_exists(client, index_name, index_config)

--- a/tests/test_memorystore_redis_vectorstore.py
+++ b/tests/test_memorystore_redis_vectorstore.py
@@ -245,11 +245,12 @@ def check_index_exists(
         and index_info["index_definition"][3][0].decode("utf-8") == index_config.name
         and index_info["attributes"][0][1].decode("utf-8") == index_config.field_name
         and index_info["attributes"][0][3].decode("utf-8") == index_config.field_name
-        and index_info["attributes"][0][5] == b'VECTOR'
+        and index_info["attributes"][0][5] == b"VECTOR"
         and index_info["attributes"][0][7][3] == index_config.vector_size
-        and index_info["attributes"][0][7][5].decode("utf-8") == index_config.distance_metric
+        and index_info["attributes"][0][7][5].decode("utf-8")
+        == index_config.distance_metric
         and index_info["attributes"][0][7][7].decode("utf-8") == index_config.data_type
-        and index_info["attributes"][0][7][9][1] == b'HNSW'
+        and index_info["attributes"][0][7][9][1] == b"HNSW"
         and index_info["attributes"][0][7][9][3] == index_config.m
         and index_info["attributes"][0][7][9][5] == index_config.ef_construction
         and index_info["attributes"][0][7][9][7] == index_config.ef_runtime


### PR DESCRIPTION
- Fixed inclusion of HNSW parameters (M, EF_CONSTRUCTION, EF_RUNTIME) in Redis index creation.
- Corrected test assertions to accurately reflect expected key count in Redis.
- Updated check_index_exists to properly validate HNSW index configurations.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/langchain-google-memorystore-redis-python/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
